### PR TITLE
feat: google tag manager setup

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -202,6 +202,10 @@ module.exports = {
           changefreq: "daily",
           priority: 0.5,
           trailingSlash: false
+        },
+        gtag: {
+          trackingID: "GTM-TPST72K",
+          anonymizeIP: true
         }
       }
     ]


### PR DESCRIPTION
Setup done using the [docs site](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag)